### PR TITLE
Fix questionnaire pipeline: LFS-track oversized data files + alert on failure

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 *.parquet filter=lfs diff=lfs merge=lfs -text
+src/public/analysis_data.json filter=lfs diff=lfs merge=lfs -text
+src/generate_site/questionnaire_links.csv filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/daily-questionnaire-analysis.yml
+++ b/.github/workflows/daily-questionnaire-analysis.yml
@@ -14,6 +14,7 @@ permissions:
   id-token: write
   pull-requests: write
   actions: write
+  issues: write  # open a tracking issue if the run fails
 
 # Node 20 runs out of stack walking the 120k-file workspace; opt into Node 24.
 env:
@@ -162,3 +163,26 @@ jobs:
         gh workflow run deploy-site.yml --ref main
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Open an issue if the run failed
+      # Mirrors daily-data-update.yml. Fires on any job failure — the
+      # most common is the push to questionnaire-updates being rejected
+      # (e.g. a generated file exceeding GitHub's 100 MB limit), which
+      # otherwise fails silently and freezes the site's data.
+      if: failure()
+      uses: actions/github-script@v7
+      with:
+        script: |
+          await github.rest.issues.create({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            title: `Daily Questionnaire Analysis Failed - ${new Date().toISOString().split('T')[0]}`,
+            body: `The daily questionnaire analysis workflow failed, so the site's questionnaire data did not update.
+
+            Questionnaire tests: ${{ steps.questionnaire_tests.outcome }}
+
+            Common cause: the push to \`questionnaire-updates\` was rejected because a generated file (e.g. \`src/public/analysis_data.json\`) exceeded GitHub's 100 MB limit. Check the log's push step.
+
+            [View the workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
+            labels: ['bug', 'automated'],
+          });

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           ref: main
           fetch-depth: 1
+          # analysis_data.json is stored in Git LFS; pull it so Netlify
+          # receives the real file rather than the LFS pointer text.
+          lfs: true
 
       - name: Deploy to Netlify
         uses: jsmrcaga/action-netlify-deploy@v2.4.0


### PR DESCRIPTION
## Why

The **Daily Questionnaire Analysis** workflow has failed every day since June 5 (last success June 4). The site's questionnaire data has been frozen since then.

**Root cause:** the regenerated `src/public/analysis_data.json` is now ~102 MB, over GitHub's hard **100 MB push limit**. The push to `questionnaire-updates` is rejected by the pre-receive hook, so the run fails, never merges to main, and never deploys. The failure was silent — unlike `daily-data-update.yml`, this workflow had no failure alert.

```
remote: error: File src/public/analysis_data.json is 101.92 MB; this exceeds GitHub's file size limit of 100.00 MB
! [remote rejected]  questionnaire-updates -> questionnaire-updates (pre-receive hook declined)
```

## Changes

1. **`.gitattributes`** — track `src/public/analysis_data.json` and `src/generate_site/questionnaire_links.csv` (56 MB, climbing) via Git LFS, same as the existing `*.parquet` rule. The next pipeline run stores the regenerated JSON as an LFS object, so the push succeeds.
2. **`deploy-site.yml`** — add `lfs: true` to the checkout. Required: otherwise the deploy ships the LFS *pointer* to Netlify instead of the real JSON and breaks the live site.
3. **`daily-questionnaire-analysis.yml`** — add `issues: write` + a `if: failure()` step that opens a tracking issue, mirroring `daily-data-update.yml`. So a future failure is visible, not silent.

## After merge

Manually dispatch **Daily Questionnaire Analysis** to regenerate + push the data as LFS and re-deploy (the next scheduled run would also do this at 9 AM UTC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)